### PR TITLE
Performance Improvement - Bundle check before bundle

### DIFF
--- a/bin/muggler
+++ b/bin/muggler
@@ -170,7 +170,7 @@ function cmd_sync {
 		local mdw="$(echo -n "${mdiff}" | egrep "^<" | cut -f 2 -d ' ')"
 		local mup="$(echo -n "${mdiff}" | egrep "^>" | cut -f 2 -d ' ')"
 
-		echo "-> $(bundle check)" | tee "${log}"
+		bundle check >> "${log}"
 		if [ $? -eq 1 ]; then
 			echo "-> Running bundler (this might take a while)" | tee "${log}"
 			bundle >> "${log}"

--- a/bin/muggler
+++ b/bin/muggler
@@ -170,8 +170,11 @@ function cmd_sync {
 		local mdw="$(echo -n "${mdiff}" | egrep "^<" | cut -f 2 -d ' ')"
 		local mup="$(echo -n "${mdiff}" | egrep "^>" | cut -f 2 -d ' ')"
 
-		echo "-> Running bundler (this might take a while)" | tee "${log}"
-		bundle >> "${log}"
+		echo "-> $(bundle check)" | tee "${log}"
+		if [ $? -eq 1 ]; then
+			echo "-> Running bundler (this might take a while)" | tee "${log}"
+			bundle >> "${log}"
+		fi
 
 		echo "-> Loading rails application and running migrations..."
 		bundle exec rails runner "$(prefix)/libexec/migrator.rb" "${1}" "${mdw}" "${mup}" "${log}" >> "${log}"


### PR DESCRIPTION
Improves the performance when switching branches that have db migration by running a `bundle check`  before `bundle`.

```
> time bundle
        8.38 real         7.38 user         0.67 sys
> time bundle check
        0.79 real         0.64 user         0.09 sys
```